### PR TITLE
Optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -18,112 +18,167 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 public final class FindMeetingQuery {
 
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     int requestDuration = (int) request.getDuration();
 
-    //if there are no events and the request duration is less than a day, return the whole day
+    // If there are no events and the request duration is less than a day, return the whole day
     if (events.isEmpty() && requestDuration <= TimeRange.WHOLE_DAY.duration()){
         return Arrays.asList(TimeRange.WHOLE_DAY);
     }
-    //if the requested meeting is longer than a day, return an empty list since this is not possible
+
+    // If the requested meeting is longer than a day, return an empty list since this is not possible
     if (requestDuration > TimeRange.WHOLE_DAY.duration()) {
         return Collections.emptyList();
     }
 
-    //an arraylist to hold an ordered list without duplicates of all busy times in a day
-    ArrayList<TimeRange> busyTimes = new ArrayList<TimeRange>();
+    // Create a map to hold an ordered pair without duplicates of all events in the day. The Boolean is true if there are optional attendees attending this event, otherwise it's false
+    TreeMap<TimeRange, Boolean> busyTimes = new TreeMap<>(new Comparator<TimeRange>() {
+         @Override
+            public int compare(TimeRange s1, TimeRange s2) {
+                return TimeRange.ORDER_BY_START.compare(s1, s2);
+            }
+    });
 
-    //adding the beginning and end of the day as endpoints (your meeting can't be before the beginning of the day or after the end of the day)
-    busyTimes.add(TimeRange.fromStartDuration(0, 0));
-    busyTimes.add(TimeRange.fromStartDuration(1440,0));
+    // Add the beginning and end of the day as endpoints (the meeting can't be before the beginning of the day or after the end of the day)
+    busyTimes.put(TimeRange.fromStartDuration(0, 0), new Boolean(false));
+    busyTimes.put(TimeRange.fromStartDuration(1440,0), new Boolean(false));
 
-    for (Event event : events){
-        //create a timerange for the event we're evaluating
+    for (Event event : events){        
+        // Create a timerange for the event that is currently being evaluated
         TimeRange newEvent = TimeRange.fromStartEnd(event.getWhen().start(), event.getWhen().duration()+event.getWhen().start(), false);
         int newEventStart = newEvent.start();
         int newEventEnd = newEvent.end();
 
-        //if none of the attendees in the request are attending this event, don't add it to BusyTimes because it's not relevant
+        // If none of the attendees in the request are attending this event, don't add it to BusyTimes because it's not relevant
         Set<String> eventAttendees = event.getAttendees();
-        Collection<String> requestAttendees = request.getAttendees();
-        if (Collections.disjoint(eventAttendees, requestAttendees)){
+        Collection<String> requestMandatoryAttendees = request.getAttendees();
+        Collection<String> requestOptionalAttendees = request.getOptionalAttendees();
+        if (Collections.disjoint(eventAttendees, requestMandatoryAttendees) && Collections.disjoint(eventAttendees, requestOptionalAttendees)){
             continue;
         }
 
-        for (int i = 0; i < busyTimes.size()-1; i++) {
-            int currentBusyStart = busyTimes.get(i).start();
-            int currentBusyEnd = busyTimes.get(i).end();
-            int nextBusyStart = busyTimes.get(i+1).start();
-            int nextBusyEnd = busyTimes.get(i+1).end();
+        for (Map.Entry<TimeRange, Boolean> busyTime : busyTimes.entrySet()) {
+            // Need to stop at the second last element because comparisons are done between the current and next busy time
+            if (busyTime.getKey() == busyTimes.lastKey()) {
+                break;
+            }
+
+            Map.Entry<TimeRange, Boolean> nextBusyTime = busyTimes.higherEntry(busyTime.getKey());
+            int currentBusyStart = busyTime.getKey().start();
+            int currentBusyEnd = busyTime.getKey().end();
+            int nextBusyStart = nextBusyTime.getKey().start();
+            int nextBusyEnd = nextBusyTime.getKey().end();
             int adjustedNewStart;
             int adjustedNewEnd;
 
-            //if the current busy time contains the new event, or they are equal, do not add the new event to the arraylist as it already exists
+            // If the current busy time contains the new event, or they are equal, do not add the new event to the arraylist as it already exists
             /*****/  //current busy block
              /**/    //new event
-            if (busyTimes.get(i).contains(newEvent) || busyTimes.get(i).equals(newEvent)){
+            if (busyTime.getKey().contains(newEvent) || busyTime.getKey().equals(newEvent)){
                 break; 
             }
-            //if the new event starts during the current busy time and ends before the next busy time
+            // If the new event starts during the current busy time and ends before the next busy time
             /*******/        /**/       //busy blocks
                  /******/               //new event
-            else if (TimeRange.contains(busyTimes.get(i), newEventStart) && newEventEnd <= nextBusyStart) {
+            else if (TimeRange.contains(busyTime.getKey(), newEventStart) && newEventEnd <= nextBusyStart) {
                 adjustedNewStart = currentBusyEnd;
                 adjustedNewEnd = newEventEnd;
             }
-            //if the new event's start is during the current busy time and it's end is in the next busy time, fill in the time between the busy times
+            // If the new event's start is during the current busy time and it's end is in the next busy time, fill in the time between the busy times
             /****/   /****/     //busy blocks
               /********/        //new event
-            else if (TimeRange.contains(busyTimes.get(i), newEventStart) && TimeRange.contains(busyTimes.get(i+1), newEventEnd)) {
+            else if (TimeRange.contains(busyTime.getKey(), newEventStart) && TimeRange.contains(nextBusyTime.getKey(), newEventEnd)) {
                 adjustedNewStart = currentBusyEnd;
                 adjustedNewEnd = nextBusyStart;
             }
-            //if the new event is strictly between the current and next busy times, add it as is
+            // If the new event is strictly between the current and next busy times, add it as is
             /***/        /***/      //busy blocks
                    /**/             //new event
             else if (newEventStart >= currentBusyEnd && newEventEnd <= nextBusyStart) {
                 adjustedNewStart = newEventStart;
                 adjustedNewEnd = newEventEnd;
             }
-            //if it's start time is after the current busy block's end time and it's end time is during the next busy time
+            // If it's start time is after the current busy block's end time and it's end time is during the next busy time
             /***/        /***/      //busy blocks
                     /*****/         //new event            
-            else if (newEventStart >= currentBusyEnd && newEventStart < nextBusyStart && TimeRange.contains(busyTimes.get(i+1), newEventEnd)) {
+            else if (newEventStart >= currentBusyEnd && newEventStart < nextBusyStart && TimeRange.contains(nextBusyTime.getKey(), newEventEnd)) {
                 adjustedNewStart = newEventStart;
                 adjustedNewEnd = nextBusyStart;
             }
-            //the new event does not start during the current busy block or before the next busy block, so move on to next busy block
+            // The new event does not start during the current busy block or before the next busy block, so move on to next busy block
             else {
                 continue;
             }
 
-            //add the new busy time with the adjusted start and duration
-            busyTimes.add(TimeRange.fromStartEnd(adjustedNewStart, adjustedNewEnd, false));
-            //sort the list in chronological order by event start time
-            Collections.sort(busyTimes, TimeRange.ORDER_BY_START);
+            // If the event doesn't have optional attendees from the request, add a busy time and indicate no optional attendees 
+            if (Collections.disjoint(eventAttendees, requestOptionalAttendees)){
+                busyTimes.put(TimeRange.fromStartEnd(adjustedNewStart, adjustedNewEnd, false), new Boolean (false));
+
+            }
+            else {
+                // Add the new busy time with the adjusted start and duration, and indicate there are optional attendees
+                busyTimes.put(TimeRange.fromStartEnd(adjustedNewStart, adjustedNewEnd, false), new Boolean (true));                
+            }
             break;
         }
     }
 
-    //list of meeting times to return as possible solutions
-    ArrayList<TimeRange> meetingTimes = new ArrayList<TimeRange>();
+    // Lists of meeting times to return as possible solutions
+    ArrayList<TimeRange> meetingTimesAllAttendees = new ArrayList<TimeRange>();
+    ArrayList<TimeRange> meetingTimesOnlyMandatory = new ArrayList<TimeRange>();
 
-    for (int i = 0; i < busyTimes.size()-1; i++){
-        int currentBusyEnd =  busyTimes.get(i).end();
-        int nextBusyStart = busyTimes.get(i+1).start();
+    for (Map.Entry<TimeRange, Boolean> busyTime : busyTimes.entrySet()){
+        // Need to stop at the second last element
+        if (busyTime.getKey() == busyTimes.lastKey()) {
+            break;
+        }
+        Map.Entry<TimeRange, Boolean> nextBusyTime = busyTimes.higherEntry(busyTime.getKey());
+        int currentBusyEnd =  busyTime.getKey().end();
+        int nextBusyStart = nextBusyTime.getKey().start();
         int timeSlot = nextBusyStart - currentBusyEnd;
 
-        if (timeSlot >= requestDuration){
-            meetingTimes.add(TimeRange.fromStartDuration(currentBusyEnd, timeSlot));
+        if (timeSlot >= requestDuration) {
+            // If there are optional attendees, add this time slot to the meeting times with all attendees
+            if (busyTime.getValue() == true){
+                meetingTimesAllAttendees.add(TimeRange.fromStartDuration(currentBusyEnd, timeSlot));
+            }
+            // If the busy time did not have optional attendees, add this time slot to the meeting times list for only mandatory attendees
+            else {
+                meetingTimesOnlyMandatory.add(TimeRange.fromStartDuration(currentBusyEnd, timeSlot));
+            }
+        }
+        // If the timeslot isn't big enough for the requested meeting's duration, there are so far no meetings with only mandatory attendees and there are mandatory
+        // attendees in the request, compare the current busy time with the next busy time that ONLY has mandatory attendees to see if you can find a meeting without 
+        // optional attendees
+        else {
+            if (meetingTimesOnlyMandatory.isEmpty() && (!request.getAttendees().isEmpty())) {
+                while(nextBusyTime.getValue() == true){
+                    nextBusyTime = busyTimes.higherEntry(nextBusyTime.getKey());
+                }
+                nextBusyStart = nextBusyTime.getKey().start();
+                timeSlot = nextBusyStart - currentBusyEnd;
+                if (timeSlot >= requestDuration) {
+                    meetingTimesOnlyMandatory.add(TimeRange.fromStartDuration(currentBusyEnd, timeSlot));
+                }
+            }
         }
     }
-    
-    return meetingTimes;
+
+    // If there are possible solutions with all the attendees, return them. Otherwise, return those only for mandatory attendees
+    if (meetingTimesAllAttendees.size() >= 1) {
+        return meetingTimesAllAttendees;
+    }
+    else {
+        return meetingTimesOnlyMandatory;
+    }
   }
 }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimeRange.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/TimeRange.java
@@ -32,7 +32,12 @@ public final class TimeRange {
   public static final Comparator<TimeRange> ORDER_BY_START = new Comparator<TimeRange>() {
     @Override
     public int compare(TimeRange a, TimeRange b) {
-      return Long.compare(a.start, b.start);
+      if (a.start == b.start) {
+        return Long.compare(a.duration, b.duration);
+      }
+      else {
+        return Long.compare(a.start, b.start); 
+      }
     }
   };
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,10 +34,12 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+    private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -94,7 +96,67 @@ public final class FindMeetingQueryTest {
     Assert.assertEquals(expected, actual);
   }
 
+
   @Test
+  public void optionalAttendeeBusyAllDay() {
+    // one optional attendee is busy the entire day. 
+    //
+    // Events  : |-------C optional------------|
+    //                 |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true), Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void considerOptionalAttendee() { 
+    // One optional attendee is busy while mandatory attendees are free, but there are meeting times that work for all three
+    // Events  :             |--C--| (optional)
+    //                 |--A--|     |--B--| (required)
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), 
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+    @Test
   public void everyAttendeeIsConsidered() {
     // Have each person have different events. We should see two options because each person has
     // split the restricted times.
@@ -200,6 +262,32 @@ public final class FindMeetingQueryTest {
   }
 
   @Test
+  public void shorterMeetingWithOptionalAttendee() {
+    // An optional attendee shortens the available time for mandatory attendees, so ignore the optional attendee
+    // Events  : |--A--|     |----A----|    (mandatory)
+    //                 |-B-|                (optional)
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
   public void justEnoughRoom() {
     // Have one person, but make it so that there is just enough room at one point in the day to
     // have the meeting.
@@ -264,6 +352,53 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalWithGaps() {
+    // Only optional attendees are attending and there are multiple options for meeting times
+    // Events  : |--A---|   |-B-|           (A and B are optional)
+    // Day     : |---------------------|
+    // Options :        |---|   |------|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TIME_0930AM, false),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false), 
+        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalWithNoGaps() {
+    // Have only optional attendees request a meeting, but there is not enough time for their requested meeting
+    // Events  : |--A---|  |----B------|    (A and B are optional)
+    // Day     : |---------------------|
+    // Options :        
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0845AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();


### PR DESCRIPTION
Add a new feature to the calendar that allows meetings to be selected while prioritizing mandatory attendees over optional attendees. If one or mote possible meeting times exist for all attendees, return them. Otherwise, return the time slots that only work for mandatory attendees. Five tests were also added to ensure this new functionality is working as expected.